### PR TITLE
now integration tests run nancy selfhosted without elevated permissions....

### DIFF
--- a/IntegrationTests.Nancy/Host.cs
+++ b/IntegrationTests.Nancy/Host.cs
@@ -1,5 +1,4 @@
 using System;
-using IntegrationTests.Nancy.Modules;
 using Nancy.Hosting.Self;
 
 namespace IntegrationTests.Nancy
@@ -8,9 +7,10 @@ namespace IntegrationTests.Nancy
     {
         private readonly NancyHost host;
 
-        public Host(string path = "http://127.0.0.1:1234")
+        public Host(string path = "http://localhost:1234")
         {
-            host = new NancyHost(new AuthenticationBootstrapper(), new Uri(path));
+            var configuration = new HostConfiguration { RewriteLocalhost = false };
+            host = new NancyHost(new Uri(path), new AuthenticationBootstrapper(), configuration);
         }
 
         public void Start()

--- a/IntegrationTests.NancyConsole/Program.cs
+++ b/IntegrationTests.NancyConsole/Program.cs
@@ -9,7 +9,7 @@ namespace IntegrationTests.NancyConsole
         {
             var host = new Host();
             host.Start();
-            Console.WriteLine("Host up at http://127.0.0.1:1234, press any key to quit");
+            Console.WriteLine("Host up at http://localhost:1234, press any key to quit");
             Console.ReadLine();
             host.Stop();
         }

--- a/IntegrationTests/IntegrationTests.csproj
+++ b/IntegrationTests/IntegrationTests.csproj
@@ -37,6 +37,10 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Nancy.0.16.1\lib\net40\Nancy.dll</HintPath>
     </Reference>
+    <Reference Include="Nancy.Hosting.Self, Version=0.16.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Nancy.Hosting.Self.0.16.1\lib\net40\Nancy.Hosting.Self.dll</HintPath>
+    </Reference>
     <Reference Include="nunit.framework">
       <HintPath>..\packages\NUnit.2.5.10.11092\lib\nunit.framework.dll</HintPath>
     </Reference>

--- a/IntegrationTests/IntegrationTestsBase.cs
+++ b/IntegrationTests/IntegrationTestsBase.cs
@@ -9,9 +9,9 @@ namespace IntegrationTests
         private Host host;
 
         /// <summary>
-        /// http://127.0.0.1:1234, found in IntegrationTests.Nancy project
+        /// http://localhost:1234, found in IntegrationTests.Nancy project
         /// </summary>
-        protected readonly string BaseUrl = "http://127.0.0.1:1234";
+        protected readonly string BaseUrl = "http://localhost:1234";
 
         [TestFixtureSetUp]
         public void BeforeAllTests()

--- a/IntegrationTests/NoAuthenticationTests.cs
+++ b/IntegrationTests/NoAuthenticationTests.cs
@@ -7,7 +7,7 @@ namespace IntegrationTests
     [Category("Integration")]
 	public class NoAuthenticationTests : IntegrationTestsBase
 	{
-        protected readonly string BaseUrl = "http://127.0.0.1:1234";
+        protected readonly string BaseUrl = "http://localhost:1234";
 	    private HttpSession session;
 
 	    [SetUp]


### PR DESCRIPTION
... { http://blog.differentpla.net/post/UaY8yQFqM2ZBAAAF/using-iis-express-in-vs-welcome-page }

I'm not Nancy expert, but I believe it should be ok _not_ to require elevated privileges to run the integrationtests.  
